### PR TITLE
Enable CORS in http.c

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -365,15 +365,17 @@ http_send_header(http_connection_t *hc, int rc, const char *content,
   htsbuf_qprintf(&hdrs, "%s %d %s\r\n", 
 		 http_ver2str(hc->hc_version), rc, http_rc2str(rc));
 
-  if (hc->hc_version != RTSP_VERSION_1_0){
+if (hc->hc_version != RTSP_VERSION_1_0) {
     htsbuf_qprintf(&hdrs, "Server: %s\r\n", config_get_http_server_name());
+    
+    // Check if CORS is enabled and a specific origin is provided
     if (config.cors_origin && config.cors_origin[0]) {
-      htsbuf_qprintf(&hdrs, "Access-Control-Allow-Origin: %s\r\n%s%s%s", config.cors_origin,
-                            "Access-Control-Allow-Methods: POST, GET, OPTIONS\r\n",
-                            "Access-Control-Allow-Headers: x-requested-with,authorization,content-type\r\n",
-                            "Access-Control-Allow-Credentials: true\r\n");
+        htsbuf_qprintf(&hdrs, "Access-Control-Allow-Origin: %s\r\n", config.cors_origin);
+        htsbuf_qprintf(&hdrs, "Access-Control-Allow-Methods: POST, GET, OPTIONS\r\n");
+        htsbuf_qprintf(&hdrs, "Access-Control-Allow-Headers: x-requested-with,authorization,content-type\r\n");
+        htsbuf_qprintf(&hdrs, "Access-Control-Allow-Credentials: true\r\n");
     }
-  }
+}
   
   if(maxage == 0) {
     if (hc->hc_version != RTSP_VERSION_1_0)


### PR DESCRIPTION
Changes Made:
Added CORS headers to the TVHeadend web server to allow cross-origin requests.
Updated the src/http.c file to include the necessary headers for CORS support.
Purpose:
The TVHeadend web server currently sends headers that do not allow for CORS requests, causing issues in certain scenarios. This pull request addresses the problem by modifying the source code to include the required CORS headers.

Additional Information:
The CORS headers added:
Access-Control-Allow-Origin: *
Access-Control-Allow-Methods: POST, GET, OPTIONS
Access-Control-Allow-Headers: x-requested-with,authorization,content-type
Access-Control-Allow-Credentials: true
Addes header  "Access-Control-Allow-Origin: *"